### PR TITLE
feat: add Questa certify flow to sim/core/Makefile

### DIFF
--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -359,3 +359,105 @@ certify: verilate
 
 .PHONY: gen-certify
 gen-certify: gen certify
+
+###############################################################################
+# Questa (vsim) certification flow
+# Useful to cross-check Verilator results, e.g. to rule out UNOPTFLAT-related
+# mismodelling for iterative FPU operations (fdiv, fsqrt).
+#
+# Usage:
+#   make questa-compile [CV_CORE_CONFIG=rv32imcf]   # compile once
+#   make certify-vsim   [CV_CORE_CONFIG=rv32imcf]   # run all ELFs
+#   make gen-certify-vsim [CV_CORE_CONFIG=rv32imcf] # gen + compile + run
+
+VSIM        ?= /home/marin/altera/25.1std/questa_fse/linux_x86_64/vsim
+VLOG        ?= /home/marin/altera/25.1std/questa_fse/linux_x86_64/vlog
+VOPT        ?= /home/marin/altera/25.1std/questa_fse/linux_x86_64/vopt
+
+VSIM_WORK_DIR    = $(SIM_RESULTS)/questa_$(CV_CORE_CONFIG)
+VSIM_LOG_DIR     = $(VSIM_WORK_DIR)/logs
+VSIM_OPT_TOP     = tb_top_opt
+
+VLOG_FLAGS  = -sv -work $(VSIM_WORK_DIR) \
+              +define+FPU_EN=$(CERT_FPU_EN) \
+              -suppress 2583
+VOPT_FLAGS  = -work $(VSIM_WORK_DIR) \
+              +acc -o $(VSIM_OPT_TOP)
+VSIM_MAX_CYCLES ?= 2000000
+VSIM_FLAGS  = -work $(VSIM_WORK_DIR) \
+              -batch -quiet \
+              -sv_seed 0 \
+              +nowarnTSCALE \
+              -suppress 8386 \
+              -suppress 3009 \
+              -do "run -all; quit -f" \
+              +maxcycles=$(VSIM_MAX_CYCLES)
+
+.PHONY: questa-compile
+questa-compile: CV_CORE_pkg
+	@echo "$(BANNER)"
+	@echo "* Compiling CORE TB and CV32E40P with Questa (CV_CORE_CONFIG=$(CV_CORE_CONFIG))"
+	@echo "$(BANNER)"
+	mkdir -p $(VSIM_WORK_DIR)
+	$(VLOG) $(VLOG_FLAGS) -f $(CV_CORE_MANIFEST)
+	$(VLOG) $(VLOG_FLAGS) $(TBSRC_PKG)
+	$(VLOG) $(VLOG_FLAGS) $(TBSRC_VERI)
+	$(VOPT) $(VOPT_FLAGS) \
+		-G FPU_EN=$(CERT_FPU_EN) \
+		tb_top
+
+.PHONY: certify-vsim
+certify-vsim: TEST = certification_$(CV_CORE_CONFIG)
+certify-vsim:
+	@echo "$(BANNER)"
+	@echo "* Running ALL compliance ELFs with Questa (CV_CORE_CONFIG=$(CV_CORE_CONFIG))"
+	@echo "$(BANNER)"
+	@set -e; \
+	mkdir -p "$(VSIM_LOG_DIR)"; \
+	SUMMARY="$(VSIM_LOG_DIR)/certification_summary.txt"; \
+	echo "RESULT  TEST" > "$$SUMMARY"; \
+	echo "------  ----" >> "$$SUMMARY"; \
+	ROOT="$(certification_PROGRAM_PATH)/rv32i"; \
+	ELFS="$$(find -L "$$ROOT" \( -type f -o -type l \) -a \( -iname '*.elf' -o -iname '*.elf32' \) 2>/dev/null | sort)"; \
+	if [ -z "$$ELFS" ]; then \
+	  echo "No .elf files found under $$ROOT"; \
+	  echo "Debug listing (2 levels):"; \
+	  find "$$ROOT" -maxdepth 2 -print || true; \
+	  exit 2; \
+	fi; \
+	PASS=0; FAIL=0; TOTAL=0; \
+	for ELF in $$ELFS; do \
+	  TOTAL=$$((TOTAL+1)); \
+	  REL="$${ELF#$$ROOT/}"; \
+	  BASE="$${ELF%.*}"; \
+	  HEX="$$BASE.hex"; \
+	  LOG="$(VSIM_LOG_DIR)/$${REL%.*}.log"; \
+	  mkdir -p "$$(dirname "$$LOG")"; \
+	  if [ ! -f "$$HEX" ] || [ "$$ELF" -nt "$$HEX" ]; then \
+	    riscv64-unknown-elf-objcopy -O verilog "$$ELF" "$$HEX"; \
+	  fi; \
+	  ENTRY=$$(riscv64-unknown-elf-readelf -h "$$ELF" | awk '/Entry point/{print $$NF}'); \
+	  ENTRY_HEX=$${ENTRY#0x}; \
+	  set +e; \
+	  $(VSIM) $(VSIM_FLAGS) \
+	    $(VSIM_OPT_TOP) \
+	    "+test_program=$$HEX" \
+	    "+boot_addr=$$ENTRY_HEX" \
+	    > "$$LOG" 2>&1; \
+	  RC=$$?; \
+	  set -e; \
+	  if [ $$RC -eq 0 ] && grep -q "ALL TESTS PASSED" "$$LOG"; then \
+	    echo "PASS    $$REL" | tee -a "$$SUMMARY"; \
+	    PASS=$$((PASS+1)); \
+	  else \
+	    echo "FAIL    $$REL" | tee -a "$$SUMMARY"; \
+	    FAIL=$$((FAIL+1)); \
+	  fi; \
+	done; \
+	echo "" | tee -a "$$SUMMARY"; \
+	echo "TOTAL=$$TOTAL PASS=$$PASS FAIL=$$FAIL" | tee -a "$$SUMMARY"; \
+	echo "Summary saved to: $$SUMMARY"; \
+	true
+
+.PHONY: gen-certify-vsim
+gen-certify-vsim: gen questa-compile certify-vsim

--- a/tb/core/mm_ram.sv
+++ b/tb/core/mm_ram.sv
@@ -232,33 +232,25 @@ module mm_ram
                 rnd_stall_regs[RND_STALL_DATA_MAX]    = 8;
             end
             else begin
-                randcase
-                    2: begin
-                        // No delays
-                    end
-                    1: begin
-                        // Create RAM stall delays
-                        rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
-                        rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
-                        rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
-                        rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
-                        rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
-                    end
-                endcase
+                // randcase 2:no-delay 1:stall replaced with $urandom_range to
+                // avoid svverification license requirement (Questa FSE)
+                if ($urandom_range(0, 2) == 0) begin
+                    // Create RAM stall delays
+                    rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
+                    rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
+                    rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
+                    rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
+                    rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
+                end
 
-                randcase
-                    2: begin
-                        // No delays
-                    end
-                    1: begin
-                        // Create RAM stall delays
-                        rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
-                        rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
-                        rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
-                        rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
-                        rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
-                    end
-                endcase
+                if ($urandom_range(0, 2) == 0) begin
+                    // Create RAM stall delays
+                    rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
+                    rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
+                    rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
+                    rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
+                    rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
+                end
             end
         end
 


### PR DESCRIPTION
Add questa-compile, certify-vsim, and gen-certify-vsim targets to allow running ACT4 compliance ELFs through Questa as a cross-check against Verilator.

Key implementation details:
- Compile RTL and TB in 3 ordered vlog passes (RTL flist, then perturbation_defines pkg, then TBSRC_VERI) so package dependencies are resolved before consumers
- Replace randcase in mm_ram.sv with equivalent if/urandom_range to avoid requiring the svverification license (Questa FSE)
- Strip 0x prefix from ELF entry point before passing as +boot_addr plusarg: Questa %h format does not accept 0x prefix unlike Verilator
- Add -do 'run -all; quit -f' and +maxcycles to ensure batch simulation terminates even if exit conditions are not reached
- VSIM_MAX_CYCLES defaults to 2000000 (overridable)

Result: F-fdiv.s-00, F-fdiv.s-01, F-fsqrt.s-00 all PASS under Questa, confirming these are Verilator UNOPTFLAT mismodelling failures caused by incorrect clocking of iterative combinatorial FPU paths, not RTL bugs.