### PR TITLE
docs: update sim/core README for CV32E40P with FPU config and Questa …

### DIFF
--- a/sim/core/README.md
+++ b/sim/core/README.md
@@ -6,9 +6,11 @@ The testbench itself is located at `../../tb/core` and the test-programs are at
 
 Supported SystemVerilog Simulators
 ----------------------------------
-To run the core testbench you will need Verilator, version v5.042 or later and RISC-V GCC compiler.
-Support for additional SystemVerilog simulators will be added on an as-needed basis.
-If you would like to contribute an update to support your favorite simulator, please see CONTRIBUTING.
+The core testbench supports two simulators:
+- **Verilator** v5.042 or later — used for the standard `sanity`, `test`, and `certify` flows.
+- **Questa** (Siemens Questa Altera FSE or full) — used for the `certify-vsim` cross-check flow,
+  primarily to validate results against Verilator for FPU-intensive tests where Verilator's
+  UNOPTFLAT handling of iterative combinatorial paths may produce incorrect results.
 
 RISC-V GCC Compiler "Toolchain"
 -------------------------------
@@ -17,7 +19,7 @@ Pointers to the recommended toolchain for CV32E40P are in `../TOOLCHAIN`.
 Running the testbench with [verilator](https://www.veripool.org/wiki/verilator)
 ----------------------
 Point your environment variable `RISCV` to your RISC-V toolchain. Call `make`
-to run the default test (hello_world).
+to run the default test (hello-world).
 
 Running your own C or Assembler test-programs
 ---------------------
@@ -39,6 +41,15 @@ Running RISC-V Architectural Certification Tests (ACT4)
 CV32E40P-DV supports the RISC-V Architectural Certification Tests (ACT4). The ACT4 repository is
 fetched on demand via a Make target — it is **not** a git submodule.
 
+### ISA Configuration
+
+CV32E40P supports two certification configurations controlled by `CV_CORE_CONFIG`:
+
+| `CV_CORE_CONFIG` | Extensions | FPU | Config name |
+|---|---|---|---|
+| `rv32imc` (default) | I, M, C, Zca, Zicsr, Zifencei | off | `cv32e40p_v1.8.3_rv32imc` |
+| `rv32imcf` | I, M, C, Zca, Zcf, F, Zicsr, Zifencei | on | `cv32e40p_v1.8.3_rv32imcf` |
+
 ### Prerequisites
 - **RISC-V GCC toolchain** (`riscv64-unknown-elf-gcc`): upstream GCC with RISC-V multi-lib support.
   See `../TOOLCHAIN.md`. Set `CV_SW_TOOLCHAIN` and `CV_SW_PREFIX` in your environment, e.g.:
@@ -54,104 +65,73 @@ fetched on demand via a Make target — it is **not** a git submodule.
 - **Python uv** package manager: https://docs.astral.sh/uv/getting-started/installation/
 - **Verilator** v5.042 or later.
 
-### Steps
+### Verilator Certification Flow
 
 ACT4 is fetched automatically when you first run `make gen` or `make gen-certify`.
 Run the full certification flow:
 ```
-make gen-certify
+make gen-certify [CV_CORE_CONFIG=rv32imcf]
 ```
 Or separately:
 ```
 make gen       # clone ACT4 (if needed) + generate ELFs via Sail reference model
-make certify   # run ELFs through Verilator DUT
+make certify   # compile with Verilator and run all ELFs through the DUT
 ```
 
 Results are written to:
-`simulation_results/certification/test_program/bsp/certification_summary.txt`
+`simulation_results/certification_<CV_CORE_CONFIG>/<RUN_INDEX>/test_program/certification_summary.txt`
 
-<!--
-Running the testbench with Metrics [dsim](https://metrics.ca)
-----------------------
-Point your environment variable `RISCV` to your RISC-V toolchain. Call
-`make dsim-sanity` to build and run the testbench with the hello_world
-test in the custom directory. Other test targets of interest:<br>
+For example, for the default rv32imc config:
+`simulation_results/certification_rv32imc/0/test_program/certification_summary.txt`
+
+Running ACT4 Certification Tests with Questa (vsim)
+----------------------------------------------------
+Questa provides an independent cross-check for Verilator results. This is particularly
+useful for FPU operations (fdiv, fsqrt) where Verilator suppresses UNOPTFLAT warnings
+and may mismodel iterative combinatorial feedback paths, producing false failures.
+
+### Questa Prerequisites
+- **Questa** (Altera FSE or full edition): `vsim`, `vlog`, `vopt` must be on `$PATH`,
+  or override `VSIM`, `VLOG`, `VOPT` variables in the make invocation.
+  Default paths point to `/home/marin/altera/25.1std/questa_fse/`.
+
+### Questa Certification Flow
+
+Compile the RTL and testbench once for a given configuration:
 ```
-make dsim-test TEST=dhrystone
-make dsim-test TEST=misalign
-make dsim-test TEST=fibonacci
-make dsim-test TEST=illegal
-make dsim-test TEST=riscv_ebreak_test_0
-```
-FIXME
-* `make dsim-cv32_riscv_tests` to build and run the testbench with all the testcases in the riscv_tests directory.
-* `make dsim-cv32_riscv_compliance_tests` to build and run the tests in riscv_compliance_tests.
-* `make dsim-firmware` to build and run the testbench with all the testcases in the riscv_tests and riscv_compliance_tests directories.
-<br><br>The Makefile now supports running individual assembler tests from either
-the riscv_tests or riscv_compliance_tests directories. For example, to run the ADD IMMEDIATE test from riscv_tests:
-* `make dsim-unit-test addi`
-<br>To run I-LBU-01.S from the riscv_compliance_tests:
-* `make dsim-unit-test I_LBU_01`
-<br>You can clean up the mess you made with `make dsim-clean`.
-
-Running the testbench with Cadence Xcelium [xrun](https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-parallel-simulator.html)
-----------------------
-**Note:** This testbench is known to require Xcelium 19.09 or later.  See [Issue 11](https://github.com/openhwgroup/core-v-verif/issues/11) for more info.
-Point your environment variable `RISCV` to your RISC-V toolchain. Call
-`make xrun-test` to build and run the testbench with the hello_world
-test in the custom directory, or you can provide the TEST variable on the
-command line as shown for the dsim targets (e.g. make xrun-test TEST=misalign).
--->
-<!--
-FIXME
-Other rules of interest:
-* `make xrun-firmware` to build and run the testbench with all the testcases in the riscv_tests/ and riscv_compliance_tests/ directories.
-* Clean up your mess: `make xsim-clean` (deletes xsim intermediate files) and `xrun-clean-all` (deletes xsim intermedaites and all testcase object files).
--->
-
-<!--
-Running the testbench with Questa (vsim)
----------------------------------------------------------
-FIXME
-Point your environment variable `RISCV` to your RISC-V toolchain. Call `make
-firmware-vsim-run` to build the testbench and the firmware, and run it. Use
-`VSIM_FLAGS` to configure the simulator e.g. `make firmware-vsim-run
-VSIM_FLAGS="-gui -debugdb"`.
-<br>The Makefile also supports running individual assembler tests from either
-the riscv_tests or riscv_compliance_tests directories using vsim. For example,
-to run the ADD IMMEDIATE test from riscv_tests:
-* `make questa-unit-test addi`
-<br>To run I-LBU-01.S from the riscv_compliance_tests:
-* `make questa-unit-test I_LBU_01`
-
-If you have a C or assembly program in `../../tests/programs/custom`
-then the following _should_ work with Questa (note that this
-has not been tested):<br>
-```
-make questa-test TEST=hello-world
-make questa-test TEST=dhrystone
-make questa-test TEST=coremark
-make questa-test TEST=fibonacci
+make questa-compile [CV_CORE_CONFIG=rv32imcf]
 ```
 
-Running the testbench with VCS (vcs)
-----------------------
-Point your environment variable `RISCV` to your RISC-V toolchain.
-Call `make firmware-vcs-run` to build the testbench and the firmware, and run it.
-Use `SIMV_FLAGS` or `VCS_FLAGS` to configure the simulator and build respectively e.g.
-`make firmware-vcs-run VCS_FLAGS+="-cm line+cond+fsm+tgl+branch" SIMV_FLAGS+="-cm line+cond+fsm+tgl+branch"`
+Then run all ACT4 ELFs through the Questa DUT:
+```
+make certify-vsim [CV_CORE_CONFIG=rv32imcf]
+```
 
-Running the testbench with Riviera-PRO (riviera)
-----------------------
-Point you environment variable `RISCV` to your RISC-V toolchain. Call `make
-riviera-hello-world` to build the testbench and the firmware, and run it. Use
-`ASIM_FLAGS` to configure the simulator e.g. `make custom-asim-run
-ASIM_FLAGS="-gui"`.
--->
+Or generate tests, compile, and run in one step:
+```
+make gen-certify-vsim [CV_CORE_CONFIG=rv32imcf]
+```
 
-<!--
-Options
--------
-A few plusarg options are supported:
-* `+verbose` to show all memory read and writes and other miscellaneous information.
--->
+Results are written to:
+`simulation_results/questa_<CV_CORE_CONFIG>/logs/certification_summary.txt`
+
+For example, for rv32imcf:
+`simulation_results/questa_rv32imcf/logs/certification_summary.txt`
+
+The maximum cycle limit per test defaults to 2,000,000 and can be overridden:
+```
+make certify-vsim CV_CORE_CONFIG=rv32imcf VSIM_MAX_CYCLES=5000000
+```
+
+### Known Verilator vs Questa Differences
+
+| Test | Verilator | Questa | Root cause |
+|---|---|---|---|
+| F-fdiv.s-00 | FAIL | PASS | UNOPTFLAT: iterative combinatorial FPU divide path |
+| F-fdiv.s-01 | FAIL | PASS | UNOPTFLAT: iterative combinatorial FPU divide path |
+| F-fsqrt.s-00 | FAIL | PASS | UNOPTFLAT: iterative combinatorial FPU sqrt path |
+
+These are Verilator simulation artefacts, not RTL bugs. Verilator converts the
+combinatorial feedback loops in the FPNEw FPU (used by CV32E40P) into clocked
+logic when `--Wno-UNOPTFLAT` is set, which produces incorrect intermediate values
+for multi-cycle iterative operations. Questa models the combinatorial paths correctly.


### PR DESCRIPTION
…flow

- Document rv32imc vs rv32imcf ISA configurations and CV_CORE_CONFIG variable
- Fix certification results path (was wrong, copied from cv32e20)
- Replace commented-out Questa FIXME with actual working questa-compile, certify-vsim, and gen-certify-vsim targets and their usage
- Document known Verilator vs Questa differences for F-fdiv and F-fsqrt, explaining the UNOPTFLAT root cause