### PR TITLE
feat: add cv32e40p three-config instantiation support

### DIFF
--- a/sim/ExternalRepos.mk
+++ b/sim/ExternalRepos.mk
@@ -12,7 +12,12 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 360d272898d81806be3377193870dbf83a3ea79f
+CV_CORE_HASH   ?= 360d272898d81806be3377193870dbf83a3ea79f    # tag: cv32e40p_v1.8.3
+
+# CV32E40P v1.0.0 (RTL Freeze 2020-12-10)
+CV_CORE_V100_REPO   ?= https://github.com/openhwgroup/cv32e40p
+CV_CORE_V100_BRANCH ?= master
+CV_CORE_V100_HASH   ?= 120ac3ee79ef56a57fe07dd8701cd4ee94458fd5  # tag: cv32e40p_v1.0.0
 
 CV_VERIF_REPO   ?= https://github.com/openhwgroup/core-v-verif
 CV_VERIF_BRANCH ?= cv32e20-dv/dev

--- a/sim/core/Makefile
+++ b/sim/core/Makefile
@@ -142,10 +142,14 @@ SIM_LIBS    := $(CORE_V_VERIF)/lib/sim_libs
 
 # RTL source files for the CV32E40P core
 # DESIGN_RTL_DIR is used by CV_CORE_MANIFEST file
-CV_CORE_PKG           := $(CV32E40P_DV)/core-v-cores/$(CV_CORE_LC)
-ifeq ($(CV_CORE_CONFIG),rv32imcf)
+ifeq ($(CV_CORE_CONFIG),v1.0.0_rv32imc)
+  CV_CORE_PKG         := $(CV32E40P_DV)/core-v-cores/cv32e40p_v1.0.0
+  CV_CORE_MANIFEST    := $(CV_CORE_PKG)/cv32e40p_manifest.flist
+else ifeq ($(CV_CORE_CONFIG),rv32imcf)
+  CV_CORE_PKG         := $(CV32E40P_DV)/core-v-cores/$(CV_CORE_LC)
   CV_CORE_MANIFEST    := $(CV_CORE_PKG)/cv32e40p_fpu_manifest.flist
 else
+  CV_CORE_PKG         := $(CV32E40P_DV)/core-v-cores/$(CV_CORE_LC)
   CV_CORE_MANIFEST    := $(CV_CORE_PKG)/cv32e40p_manifest.flist
 endif
 export DESIGN_RTL_DIR  = $(CV_CORE_PKG)/rtl
@@ -165,7 +169,11 @@ check:
 	@echo "CLONE_CV_CORE_CMD = $(CLONE_CV_CORE_CMD)"
 
 # Shorthand rules for convience
+ifeq ($(CV_CORE_CONFIG),v1.0.0_rv32imc)
+CV_CORE_pkg: clone_rtl_v1.0.0
+else
 CV_CORE_pkg: clone_rtl
+endif
 
 tbsrc_pkg: $(TBSRC_PKG)
 
@@ -208,6 +216,7 @@ verilate: CV_CORE_pkg $(TBSRC_VERI) $(TBSRC_PKG)
 		--Mdir $(VERI_OBJ_DIR) \
 		-CFLAGS "-std=gnu++14 $(VERI_CFLAGS)" \
 		$(VERI_COMPILE_FLAGS) \
+		$(CERT_V100_FLAG) \
 		-GFPU_EN=$(CERT_FPU_EN)
 	mkdir -p $(SIM_RESULTS)
 	mkdir -p $(SIM_TEST_RESULTS)
@@ -240,7 +249,16 @@ clone_rtl:
 	@echo "$(BANNER)"
 	@echo "* Cloning CV32E40P RTL model"
 	@echo "$(BANNER)"
-	$(CLONE_CV_CORE_CMD)
+	if [ ! -d $(CV_CORE_PKG) ]; then $(CLONE_CV_CORE_CMD); fi
+
+clone_rtl_v1.0.0:
+	@echo "$(BANNER)"
+	@echo "* Cloning CV32E40P v1.0.0 RTL model"
+	@echo "$(BANNER)"
+	if [ ! -d $(CV32E40P_DV)/core-v-cores/cv32e40p_v1.0.0 ]; then \
+		git clone -b cv32e40p_v1.0.0 --single-branch $(CV_CORE_V100_REPO) \
+		$(CV32E40P_DV)/core-v-cores/cv32e40p_v1.0.0; \
+	fi
 
 ###############################################################################
 # clean up simulation results
@@ -263,7 +281,7 @@ clean-dist:
 	rm -rf riscv-fesvr riscv-isa-sim
 
 clean-cloned:
-	rm -rf $(CV_CORE_PKG) $(CORE_V_VERIF)
+	rm -rf $(CV_CORE_PKG) $(CORE_V_VERIF) $(CV32E40P_DV)/core-v-cores/cv32e40p_v1.0.0
 
 clean-all-banner:
 	@echo "$(BANNER)"
@@ -274,17 +292,24 @@ clean_all: clean-all-banner clean-all-targets
 #endend
 
 ###############################################################################
-# ISA configuration: rv32imc (FPU=0) or rv32imcf (FPU=1)
+# ISA configuration: rv32imc (FPU=0), rv32imcf (FPU=1), or v1.0.0_rv32imc
 CV_CORE_CONFIG ?= rv32imc
 
 ifeq ($(CV_CORE_CONFIG),rv32imcf)
   CERT_FPU_EN      = 1
   CERT_CONFIG_NAME = cv32e40p_v1.8.3_rv32imcf
   CERT_EXTENSIONS  = I,M,C,F,Zca,Zcf,Zicsr,Zifencei,Zicntr
+  CERT_V100_FLAG   =
+else ifeq ($(CV_CORE_CONFIG),v1.0.0_rv32imc)
+  CERT_FPU_EN      = 0
+  CERT_CONFIG_NAME = cv32e40p_v1.0.0_rv32imc
+  CERT_EXTENSIONS  = I,M,C,Zca,Zicsr,Zifencei,Zicntr
+  CERT_V100_FLAG   = +define+CV32E40P_V100
 else
   CERT_FPU_EN      = 0
   CERT_CONFIG_NAME = cv32e40p_v1.8.3_rv32imc
   CERT_EXTENSIONS  = I,M,C,Zca,Zicsr,Zifencei,Zicntr
+  CERT_V100_FLAG   =
 endif
 
 ###############################################################################

--- a/tb/core/tb_top.sv
+++ b/tb/core/tb_top.sv
@@ -73,6 +73,8 @@ module tb_top
 
     // IRQ (32-bit, from mm_ram)
     logic [31:0]                  irq;
+    logic                         irq_ack;
+    logic [4:0]                   irq_id;
 
     // dumps waves
     initial begin
@@ -182,11 +184,66 @@ module tb_top
 	$display("\n[%s] @ t=%0t: Verilator simulation ending...", id, $time);
     end
 
-    // cv32e40p_tb_wrapper: included via cv32e40p_manifest.flist (from RTL bhv/ dir)
+    // Core instantiation — cv32e40p_tb_wrapper (v1.8.3) or cv32e40p_wrapper (v1.0.0)
+    // Selected at compile time via +define+CV32E40P_V100 for v1.0.0 configs.
+`ifdef CV32E40P_V100
+    // v1.0.0: bhv wrapper uses PULP_* parameter names and exposes raw APU ports
+    cv32e40p_wrapper
+      #(.PULP_XPULP      (0),
+        .PULP_CLUSTER    (0),
+        .FPU             (FPU_EN),
+        .PULP_ZFINX      (0),
+        .NUM_MHPMCOUNTERS(1))
+    cv32e40p_tb_wrapper_i
+      (.clk_i               (core_clk),
+       .rst_ni              (core_rst_n),
+       .pulp_clock_en_i     (1'b1),
+       .scan_cg_en_i        (1'b0),
+       .boot_addr_i         (boot_addr),
+       .mtvec_addr_i        (boot_addr),
+       .dm_halt_addr_i      (32'h1A110800),
+       .hart_id_i           (32'h0),
+       .dm_exception_addr_i (32'h1A110808),
+       .instr_req_o         (instr_req),
+       .instr_gnt_i         (instr_gnt),
+       .instr_rvalid_i      (instr_rvalid),
+       .instr_addr_o        (instr_addr),
+       .instr_rdata_i       (instr_rdata),
+       .data_req_o          (data_req),
+       .data_gnt_i          (data_gnt),
+       .data_rvalid_i       (data_rvalid),
+       .data_we_o           (data_we),
+       .data_be_o           (data_be),
+       .data_addr_o         (data_addr),
+       .data_wdata_o        (data_wdata),
+       .data_rdata_i        (data_rdata),
+       // APU tie-offs (FPU=0 so APU is unused; v1.8.3 wraps FPU internally)
+       .apu_req_o           (),
+       .apu_gnt_i           (1'b0),
+       .apu_operands_o      (),
+       .apu_op_o            (),
+       .apu_flags_o         (),
+       .apu_rvalid_i        (1'b0),
+       .apu_result_i        (32'b0),
+       .apu_flags_i         ('0),
+       .irq_i               (irq),
+       .irq_ack_o           (irq_ack),
+       .irq_id_o            (irq_id),
+       .debug_req_i         (1'b0),
+       .debug_havereset_o   (),
+       .debug_running_o     (),
+       .debug_halted_o      (),
+       .fetch_enable_i      (1'b1),
+       .core_sleep_o        ());
+`else
+    // v1.8.3: bhv wrapper uses COREV_* parameter names
     cv32e40p_tb_wrapper
       #(.COREV_PULP      (0),
         .COREV_CLUSTER   (0),
         .FPU             (FPU_EN),
+        .FPU_ADDMUL_LAT  (0),
+        .FPU_OTHERS_LAT  (0),
+        .ZFINX           (0),
         .NUM_MHPMCOUNTERS(1))
     cv32e40p_tb_wrapper_i
       (.clk_i               (core_clk),
@@ -212,14 +269,15 @@ module tb_top
        .data_wdata_o        (data_wdata),
        .data_rdata_i        (data_rdata),
        .irq_i               (irq),
-       .irq_ack_o           (),
-       .irq_id_o            (),
+       .irq_ack_o           (irq_ack),
+       .irq_id_o            (irq_id),
        .debug_req_i         (1'b0),
        .debug_havereset_o   (),
        .debug_running_o     (),
        .debug_halted_o      (),
        .fetch_enable_i      (1'b1),
        .core_sleep_o        ());
+`endif
 
     // mm_ram: memory mapped virtual peripheral and RAM model
     mm_ram
@@ -245,8 +303,8 @@ module tb_top
          .data_rvalid_o  (data_rvalid),
          .data_gnt_o     (data_gnt),
 
-         .irq_id_i       ('0),
-         .irq_ack_i      ('0),
+         .irq_id_i       (irq_id),
+         .irq_ack_i      (irq_ack),
          .irq_o          (irq),
 
          .debug_req_o    (),


### PR DESCRIPTION
Wire tb_top.sv to support all three CTP configurations:
- cv32e40p_v1.8.3_rv32imc (FPU=0, cv32e40p_tb_wrapper, COREV_* params)
- cv32e40p_v1.8.3_rv32imcf (FPU=1, same wrapper)
- cv32e40p_v1.0.0_rv32imc (FPU=0, cv32e40p_wrapper, PULP_* params + APU tie-offs)

ExternalRepos.mk: add CV_CORE_V100_* variables for v1.0.0 clone. Makefile: conditional CV_CORE_PKG/manifest/CERT_* per CV_CORE_CONFIG;
  CV_CORE_pkg depends on clone_rtl_v1.0.0 for v1.0.0 config;
  clone targets guarded against re-cloning existing dirs;
  +define+CV32E40P_V100 passed to Verilator for v1.0.0 ifdef selection.
tb_top.sv: ifdef CV32E40P_V100 selects wrapper module and port names;
  IRQ signals (irq_ack, irq_id) wired to mm_ram instead of tied-off;
  boot_addr driven from +boot_addr plusarg (set per-test from ELF entry).